### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Node.js and npm if they are not installed
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js not found. Installing..."
+  apt-get update
+  apt-get install -y nodejs npm
+fi
+
+# Install project dependencies
+npm install
+
+# Create a default .env if one does not exist
+if [ ! -f .env ]; then
+  cat <<'EOT' > .env
+REACT_APP_SERVER_URL=http://localhost:8000
+REACT_APP_GOOGLE_API_KEY=REPLACE_WITH_YOUR_KEY
+REACT_APP_PASSWORD=changeme
+EOT
+  echo "Created default .env file. Update it with your settings."
+fi
+

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ npm run build
 
 The compiled output will be placed in the `build/` directory.
 
+## Codex Setup
+
+If you are running this project in the [Codex](https://github.com/oxidic/codex) environment,
+execute the provided setup script before running any commands:
+
+```bash
+./.codex/setup.sh
+```
+
+The script installs dependencies and creates a default `.env` file if one does not
+exist. Update the `.env` values with your actual API keys and server URL.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- add setup script for Codex
- document how to use the script in the README

## Testing
- `npm test --silent --passWithNoTests` *(fails: `react-scripts: not found`)*