### PR TITLE
Centralize chat component styling

### DIFF
--- a/src/UI/prototype/UserChatBirthChart.css
+++ b/src/UI/prototype/UserChatBirthChart.css
@@ -1,0 +1,93 @@
+.chat-container {
+  margin-top: 30px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.chat-messages {
+  height: 300px;
+  overflow-y: auto;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 10px;
+  margin-bottom: 10px;
+  background-color: #fafafa;
+}
+
+.chat-message {
+  margin-bottom: 10px;
+  padding: 8px;
+  border-radius: 4px;
+}
+
+.chat-message.user-message {
+  background-color: #e3f2fd;
+  border-left: 4px solid #2196f3;
+}
+
+.chat-message.bot-message {
+  background-color: #f5f5f5;
+  border-left: 4px solid #4caf50;
+}
+
+.chat-message.error-message {
+  background-color: #ffebee;
+  border-left: 4px solid #f44336;
+}
+
+.message-meta {
+  font-size: 12px;
+  color: #666;
+  margin-bottom: 4px;
+  font-weight: bold;
+}
+
+.timestamp {
+  font-weight: normal;
+  margin-left: 8px;
+}
+
+.message-text {
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+
+.loading-indicator {
+  padding: 8px;
+  font-style: italic;
+  color: #666;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  border-left: 4px solid #ff9800;
+}
+
+.chat-input-area {
+  display: flex;
+  gap: 10px;
+}
+
+.chat-textarea {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  resize: vertical;
+  min-height: 40px;
+  max-height: 100px;
+}
+
+.send-button {
+  padding: 8px 16px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.send-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/UI/prototype/UserChatBirthChart.js
+++ b/src/UI/prototype/UserChatBirthChart.js
@@ -1,109 +1,87 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import './UserChatBirthChart.css';
 
-const UserChatBirthChart = ({ chatMessages, currentMessage, setCurrentMessage, isChatLoading, handleSendMessage, handleKeyPress}) => {
-  
-    return (
-    <div style={{ marginTop: '30px', border: '1px solid #ddd', borderRadius: '8px', padding: '15px' }}>
-        <h3>Chat with Your Birth Chart</h3>
+const UserChatBirthChart = ({
+  chatMessages,
+  currentMessage,
+  setCurrentMessage,
+  isChatLoading,
+  isChatHistoryLoading,
+  handleSendMessage,
+  handleKeyPress,
+}) => {
+  const messagesRef = useRef(null);
+
+  useEffect(() => {
+    if (messagesRef.current) {
+      messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
+    }
+  }, [chatMessages, isChatLoading]);
+
+  return (
+    <div className="chat-container">
+      <h3>Chat with Your Birth Chart</h3>
         
-        {/* Chat Messages */}
-        <div style={{ 
-          height: '300px', 
-          overflowY: 'auto', 
-          border: '1px solid #eee', 
-          borderRadius: '4px', 
-          padding: '10px', 
-          marginBottom: '10px',
-          backgroundColor: '#fafafa'
-        }}>
-          {chatMessages.length === 0 ? (
-            <p style={{ color: '#666', fontStyle: 'italic' }}>
-              Start a conversation about your birth chart...
-            </p>
-          ) : (
-            chatMessages.map(message => (
-              <div 
-                key={message.id} 
-                style={{ 
-                  marginBottom: '10px', 
-                  padding: '8px', 
-                  borderRadius: '4px',
-                  backgroundColor: message.type === 'user' ? '#e3f2fd' : 
-                                   message.type === 'error' ? '#ffebee' : '#f5f5f5',
-                  borderLeft: `4px solid ${message.type === 'user' ? '#2196f3' : 
-                                          message.type === 'error' ? '#f44336' : '#4caf50'}`
-                }}
-              >
-                <div style={{ 
-                  fontSize: '12px', 
-                  color: '#666', 
-                  marginBottom: '4px',
-                  fontWeight: 'bold'
-                }}>
-                  {message.type === 'user' ? 'You' : 
-                   message.type === 'error' ? 'Error' : 'Birth Chart Assistant'}
-                  <span style={{ fontWeight: 'normal', marginLeft: '8px' }}>
-                    {message.timestamp.toLocaleTimeString()}
-                  </span>
-                </div>
-                <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.4' }}>
-                  {message.content}
-                </div>
+      {/* Chat Messages */}
+      <div className="chat-messages" ref={messagesRef}>
+        {isChatHistoryLoading && chatMessages.length === 0 && (
+          <div className="loading-indicator">Loading chat history...</div>
+        )}
+        {chatMessages.length === 0 && !isChatHistoryLoading ? (
+          <p className="loading-indicator">Start a conversation about your birth chart...</p>
+        ) : (
+          chatMessages.map((message) => (
+            <div
+              key={message.id}
+              className={`chat-message ${
+                message.type === 'user'
+                  ? 'user-message'
+                  : message.type === 'error'
+                  ? 'error-message'
+                  : 'bot-message'
+              }`}
+            >
+              <div className="message-meta">
+                {message.type === 'user'
+                  ? 'You'
+                  : message.type === 'error'
+                  ? 'Error'
+                  : 'Birth Chart Assistant'}
+                <span className="timestamp">
+                  {message.timestamp.toLocaleTimeString()}
+                </span>
               </div>
-            ))
-          )}
-          
-          {/* Loading indicator */}
-          {isChatLoading && (
-            <div style={{ 
-              padding: '8px', 
-              fontStyle: 'italic', 
-              color: '#666',
-              backgroundColor: '#f0f0f0',
-              borderRadius: '4px',
-              borderLeft: '4px solid #ff9800'
-            }}>
-              Birth Chart Assistant is typing...
+              <div className="message-text">{message.content}</div>
             </div>
-          )}
-        </div>
-        
-        {/* Chat Input */}
-        <div style={{ display: 'flex', gap: '10px' }}>
-          <textarea
-            value={currentMessage}
-            onChange={(e) => setCurrentMessage(e.target.value)}
-            onKeyPress={handleKeyPress}
-            placeholder="Ask about your birth chart..."
-            disabled={isChatLoading}
-            style={{
-              flex: 1,
-              padding: '8px',
-              border: '1px solid #ddd',
-              borderRadius: '4px',
-              resize: 'vertical',
-              minHeight: '40px',
-              maxHeight: '100px'
-            }}
-          />
-          <button
-            onClick={handleSendMessage}
-            disabled={!currentMessage.trim() || isChatLoading}
-            style={{
-              padding: '8px 16px',
-              backgroundColor: '#4CAF50',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              whiteSpace: 'nowrap'
-            }}
-          >
-            {isChatLoading ? 'Sending...' : 'Send'}
-          </button>
-        </div>
+          ))
+        )}
+
+        {/* Loading indicator */}
+        {isChatLoading && (
+          <div className="loading-indicator">Birth Chart Assistant is typing...</div>
+        )}
       </div>
-    );
-  };
+        
+      {/* Chat Input */}
+      <div className="chat-input-area">
+        <textarea
+          className="chat-textarea"
+          value={currentMessage}
+          onChange={(e) => setCurrentMessage(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder="Ask about your birth chart..."
+          disabled={isChatLoading}
+        />
+        <button
+          className="send-button"
+          onClick={handleSendMessage}
+          disabled={!currentMessage.trim() || isChatLoading}
+        >
+          {isChatLoading ? 'Sending...' : 'Send'}
+        </button>
+      </div>
+    </div>
+  );
+};
   
-  export default UserChatBirthChart;
+export default UserChatBirthChart;

--- a/src/pages/compositeDashboard_v4.js
+++ b/src/pages/compositeDashboard_v4.js
@@ -447,8 +447,7 @@ function CompositeDashboard_v4({}) {
 
         {/* Relationship Chat Interface - Only show when vectorization is complete */}
         {vectorizationStatus.relationshipAnalysis && userA && userB && compositeChart && (
-          <div style={{ marginTop: '30px' }}>
-            <UserChatBirthChart
+          <UserChatBirthChart
               chatMessages={chatMessages}
               currentMessage={currentMessage}
               setCurrentMessage={setCurrentMessage}
@@ -458,7 +457,6 @@ function CompositeDashboard_v4({}) {
               handleKeyPress={handleKeyPress}
               // You can customize the title by passing it as a prop if needed
             />
-          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move chat styles to `UserChatBirthChart.css`
- refactor `UserChatBirthChart` to use CSS classes
- auto-scroll chat window and show chat history loader
- remove extraneous wrapper from composite dashboard

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*