### PR TITLE
Add manual start for analysis workflows

### DIFF
--- a/src/pages/compositeDashboard_v4.js
+++ b/src/pages/compositeDashboard_v4.js
@@ -54,6 +54,7 @@ function CompositeDashboard_v4({}) {
     const [isChatHistoryLoading, setIsChatHistoryLoading] = useState(false);
     const [scoreLoading, setScoreLoading] = useState(false);
     const [analysisLoading, setAnalysisLoading] = useState(false);
+    const [workflowStarted, setWorkflowStarted] = useState(false);
 
     useEffect(() => {
         const initializeCompositeChartData = async () => {
@@ -341,6 +342,11 @@ function CompositeDashboard_v4({}) {
     }
   };
 
+  const startWorkflow = () => {
+    setWorkflowStarted(true);
+    handleWorkflow();
+  };
+
   const getNextAction = () => {
     if (!relationshipScores) return 'generateScore';
     if (!detailedRelationshipAnalysis) {
@@ -398,6 +404,7 @@ function CompositeDashboard_v4({}) {
   };
 
   useEffect(() => {
+    if (!workflowStarted) return;
     const next = getNextAction();
     if (
       next !== 'complete' &&
@@ -417,7 +424,8 @@ function CompositeDashboard_v4({}) {
     userBVectorizationStatus,
     scoreLoading,
     analysisLoading,
-    processingStatus.isProcessing
+    processingStatus.isProcessing,
+    workflowStarted
   ]);
 
   return (
@@ -440,7 +448,7 @@ function CompositeDashboard_v4({}) {
               ))}
             </div>
             <button
-              onClick={handleWorkflow}
+              onClick={startWorkflow}
               disabled={
                 scoreLoading ||
                 analysisLoading ||

--- a/src/pages/userDashboard.js
+++ b/src/pages/userDashboard.js
@@ -111,6 +111,7 @@ function UserDashboard() {
   const [isChatLoading, setIsChatLoading] = useState(false);
   const [birthChartAnalysisId, setBirthChartAnalysisId] = useState(null);
   const [isChatHistoryLoading, setIsChatHistoryLoading] = useState(false);
+  const [workflowStarted, setWorkflowStarted] = useState(false);
 
   const {
     execute: fetchAnalysisForUserAsync,
@@ -661,6 +662,12 @@ const handleKeyPress = (e) => {
   }
 };
 
+// Initialize the workflow on first button press
+const startWorkflow = () => {
+  setWorkflowStarted(true);
+  handleWorkflow();
+};
+
 // Determine which step of the workflow should run next
 const getNextAction = () => {
   if (!basicAnalysis.overview) return 'generateBasic';
@@ -719,6 +726,7 @@ const getButtonLabel = () => {
 
 // Automatically progress through the workflow when possible
 useEffect(() => {
+  if (!workflowStarted) return;
   const next = getNextAction();
   if (!globalLoading && !globalError && next !== 'complete') {
     handleWorkflow();
@@ -730,7 +738,8 @@ useEffect(() => {
   subTopicAnalysis,
   vectorizationStatus.topicAnalysis.isComplete,
   globalLoading,
-  globalError
+  globalError,
+  workflowStarted
 ]);
 
   return (
@@ -763,7 +772,7 @@ useEffect(() => {
         ))}
       </div>
       <button
-        onClick={handleWorkflow}
+        onClick={startWorkflow}
         disabled={globalLoading || getNextAction() === 'complete'}
       >
         {getButtonLabel()}


### PR DESCRIPTION
## Summary
- allow birth chart dashboard and composite dashboard workflows to start manually
- continue automatic progression after start button is pressed

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*