### PR TITLE
Improve workflow resume for topic analysis

### DIFF
--- a/src/pages/userDashboard.js
+++ b/src/pages/userDashboard.js
@@ -485,7 +485,7 @@ async function processTopicAnalysis() {
   }));
 
   try {
-    const response = await processAndVectorizeTopicAnalysis(userId);
+    const response = await processAndVectorizeTopicAnalysis(userId, vectorizationStatus);
     console.log("Processing response:", response);
     
     if (response.success) {
@@ -557,7 +557,7 @@ async function processTopicAnalysis() {
 async function generateAndReturnTopicAnalysis() {
   console.log("userId", userId);
   try {
-    const result = await generateTopicAnalysis(userId);
+    const result = await generateTopicAnalysis(userId, subTopicAnalysis);
     if (result.success) {
       setSubTopicAnalysis(result.results);
     }


### PR DESCRIPTION
## Summary
- skip previously completed subtopics when generating topic analysis
- resume topic vectorization from first unprocessed subtopic
- pass existing analysis data to API helpers in the dashboard

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b392485ac8327bb8981f10bb72af7