### PR TITLE
Fix planet card order

### DIFF
--- a/src/pages/userDashboard.js
+++ b/src/pages/userDashboard.js
@@ -1,6 +1,22 @@
 // Updated UserDashboard component with polling workflow
 
 import React, { useEffect, useState, useCallback } from 'react';
+
+// Order in which planetary interpretations should appear
+const PLANET_ORDER = [
+  'Sun',
+  'Moon',
+  'Ascendant',
+  'Mercury',
+  'Venus',
+  'Mars',
+  'Jupiter',
+  'Saturn',
+  'Uranus',
+  'Neptune',
+  'Pluto',
+  'Node'
+];
 import UserBirthChartContainer from '../UI/prototype/UserBirthChartContainer';
 import useStore from '../Utilities/store';
 import { BroadTopicsEnum, ERROR_API_CALL } from '../Utilities/constants';
@@ -579,12 +595,13 @@ function UserDashboard() {
     content: (
       <section className="planets-section">
         <div className="planet-grid">
-          {Object.entries(basicAnalysis.planets || {}).map(([planet, data]) => (
-            <div key={planet} className="planet-card">
-              <h4>{planet}</h4>
-              <p>{data.interpretation}</p>
-            </div>
-          ))}
+          {PLANET_ORDER.filter(p => basicAnalysis.planets && basicAnalysis.planets[p])
+            .map(planet => (
+              <div key={planet} className="planet-card">
+                <h4>{planet}</h4>
+                <p>{basicAnalysis.planets[planet].interpretation}</p>
+              </div>
+            ))}
         </div>
       </section>
     )

--- a/src/pages/userDashboard.tsx
+++ b/src/pages/userDashboard.tsx
@@ -1,4 +1,20 @@
 import React, { useEffect, useState, useCallback } from 'react';
+
+// Order in which planetary interpretations should appear
+const PLANET_ORDER = [
+  'Sun',
+  'Moon',
+  'Ascendant',
+  'Mercury',
+  'Venus',
+  'Mars',
+  'Jupiter',
+  'Saturn',
+  'Uranus',
+  'Neptune',
+  'Pluto',
+  'Node'
+];
 import UserBirthChartContainerfrom '../UI/prototype/UserHoroscopeContainer';
 import useStore from '../Utilities/store';
 import { BroadTopicsEnum, ERROR_API_CALL } from '../Utilities/constants';
@@ -732,12 +748,13 @@ const handleKeyPress = (e) => {
       <section className="planets-section">
         <h3>Planetary Influences</h3>
         <div className="planet-grid">
-          {Object.entries(basicAnalysis.planets || {}).map(([planet, data]) => (
-            <div key={planet} className="planet-card">
-              <h4>{planet}</h4>
-              <p>{data.interpretation}</p>
-            </div>
-          ))}
+          {PLANET_ORDER.filter(p => basicAnalysis.planets && basicAnalysis.planets[p])
+            .map(planet => (
+              <div key={planet} className="planet-card">
+                <h4>{planet}</h4>
+                <p>{basicAnalysis.planets[planet].interpretation}</p>
+              </div>
+            ))}
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- guarantee consistent ordering for planetary interpretation cards on the dashboard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847008778588327a6c1f001c997bb46