### PR TITLE
fix: send Firebase auth token on enhanced-relationship-analysis and createCeleb calls

### DIFF
--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -464,9 +464,8 @@ export const createRelationshipDirect = async (userIdA, userIdB, ownerUserId = n
       requestBody.celebRelationship = true;
     }
     
-    const response = await telemetryFetch(`${SERVER_URL}/enhanced-relationship-analysis`, {
+    const response = await authenticatedFetch(`${SERVER_URL}/enhanced-relationship-analysis`, {
       method: HTTP_POST,
-      headers: { [CONTENT_TYPE_HEADER]: APPLICATION_JSON },
       body: JSON.stringify(requestBody)
     });
 
@@ -1857,11 +1856,8 @@ export const createCelebrity = async (celebrityData) => {
     // Remove email field for celebrities (not required)
     delete requestData.email;
     
-    const response = await telemetryFetch(`${SERVER_URL}${endpoint}`, {
+    const response = await authenticatedFetch(`${SERVER_URL}${endpoint}`, {
       method: HTTP_POST,
-      headers: {
-        [CONTENT_TYPE_HEADER]: APPLICATION_JSON
-      },
       body: JSON.stringify(requestData)
     });
 


### PR DESCRIPTION
## What
Switch two `src/Utilities/api.js` call sites from `telemetryFetch` to `authenticatedFetch` (which attaches a Firebase Bearer token and sets the JSON Content-Type):
- `createRelationshipDirect` → `POST /enhanced-relationship-analysis`
- `createCelebrity` → `POST /createCeleb` / `/createCelebUnknownTime`

## Why — coupled to a backend security fix
The backend now **requires auth** on these endpoints (IDOR/billing-fraud fix, already merged to `stellium-backend` main). Without this change, the web app's calls to those routes will start returning 401 once the backend deploys. Both affected call sites already sit behind authenticated UI (`ProtectedRoute` + `stelliumUser`), so no unauthenticated caller is broken.

## ⚠️ Deploy ordering
Deploy this **with or before** the backend security change — backend-first would break web relationship creation until this lands.

## Test plan
- [ ] `DISABLE_ESLINT_PLUGIN=true CI=true npm run build` passes (verified locally)
- [ ] Create a relationship from the web app; confirm it succeeds against the auth-enforced backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)